### PR TITLE
fix: CSV references in products-import-from-xml

### DIFF
--- a/products-import-from-xml/README.md
+++ b/products-import-from-xml/README.md
@@ -1,18 +1,16 @@
-## Product Import From CSV file to PIM
+## Product Import From XML file to PIM
 
-This script imports product information from a CSV file into your Crystallize [PIM](https://crystallize.com/product/product-information-management). The script uses the [GraphQL PIM API](https://crystallize.com/api) in [Crystallize](https://crystallize.com) to create products automatically based on the contents in your CSV file.
+This script imports product information from a XML file into your Crystallize [PIM](https://crystallize.com/product/product-information-management). The script uses the [GraphQL PIM API](https://crystallize.com/api) in [Crystallize](https://crystallize.com) to create products automatically based on the contents in your XML file.
 
 You will need an access token, in order to be able to run this script. It can be obtained under settings menu on [Access Tokens](https://pim.crystallize.com/settings/access-tokens)
 
 ## The script will
 
-- Creates two new shapes, `example-csv-imp-folder` and `example-csv-imp-product`
-- Creates a new folder for all the products, "Example products CSV import"
+- Creates two new shapes, `example-xml-imp-folder` and `example-xml-imp-product`
+- Creates a new folder for all the products, "Example products XML import"
 - Creates new products under that folder
 
 ## Usage
 
 1. Install dependencies
 2. `yarn start` or `npm run start`
-
-You can also read the blog post on [CSV product import to PIM](https://crystallize.com/blog/csv-product-import-into-pim)

--- a/products-import-from-xml/index.ts
+++ b/products-import-from-xml/index.ts
@@ -45,7 +45,7 @@ async function go() {
         shape: "example-xml-imp-folder",
         children: products.map((product: any) => ({
           ...product,
-          shape: "example-csv-imp-product",
+          shape: "example-xml-imp-product",
           vatType: "Example VAT",
         })),
       },


### PR DESCRIPTION
This PR replaces all references of `csv` with `xml` in the README and index.ts of the `products-import-from-xml` example. It seems the README was taken from the `products-import-from-csv` example and it didn't reflect correctly the `xml` example. 